### PR TITLE
Add basic GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Build Electron App
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+
+    env:
+      CI: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Electron app
+        run: npm run dist -- --publish never
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-${{ matrix.os }}
+          path: dist/
+          retention-days: 7


### PR DESCRIPTION
This runs `electron-dist` in CI for Windows and macOS and uploads the artifacts so you can immediately test your changes without having to set up a development environment locally on the correct operating system.

Hopefully the `actions/upload-artifact` retention settings are short enough that we won't hit space limits?