### PR TITLE
Focus text box when opening annotation overlay

### DIFF
--- a/overlay.html
+++ b/overlay.html
@@ -42,6 +42,7 @@
     ipcRenderer.on('show-annotation-ui', () => {
       const annotationUI = document.getElementById('annotation-ui');
       if (annotationUI) annotationUI.style.display = 'flex';
+      noteInput.focus();
     });
 
     ipcRenderer.on('emoji-reaction', (event, emoji) => {


### PR DESCRIPTION
By default, the page state is retained while the overlay is hidden, meaning that clicking the "save annotation" button defocuses the text box.

This means that the next time you open the annotation window, you need to click or hit tab to re-focus the text box.

Small UI improvement to remove a papercut.