### PR TITLE
Fix "Error deleting annotation."

### DIFF
--- a/backend/aws.js
+++ b/backend/aws.js
@@ -357,8 +357,15 @@ async _safeGetSignedUrl(key) {
 
     let annotations = JSON.parse(data.Body.toString());
 
+    let oldLength = annotations.length;
+
     // 2. Filter out the entry with that timestamp (or id if you add one)
     annotations = annotations.filter(a => a.timestamp !== targetTimestamp);
+
+    if (annotations.length == oldLength) {
+      // Failed to delete something!?
+      throw `Didn't find annotation at timestamp ${targetTimestamp}`;
+    }
 
     // 3. Re-upload JSON
     await this.s3.putObject({
@@ -367,8 +374,6 @@ async _safeGetSignedUrl(key) {
       Body: JSON.stringify(annotations, null, 2),
       ContentType: "application/json"
     }).promise();
-
-    return true;
   }
 
   async saveAnnotationToS3(sessionMetadata, annotation) {

--- a/index.html
+++ b/index.html
@@ -492,11 +492,11 @@
             deleteBtn.onclick = async (e) => {
               e.stopPropagation();
               try {
-                await client.deleteAnnotation(session.username, session.annotationUrl, a.timestamp);
+                await client.deleteAnnotation(session.annotationUrl, a.timestamp);
                 note.remove();
               } catch (err) {
                 console.error("Failed to delete annotation:", err);
-                alert("Error deleting annotation.");
+                alert(`Error deleting annotation: ${err}`);
               }
             };
             note.appendChild(deleteBtn);


### PR DESCRIPTION
It turned out that `AWSManager.deleteAnnotation` was being called with incorrect arguments. I fixed the arguments and it started working again, but I also added a check to `AWSManager.deleteAnnotation` to make sure that the `Array.filter` call does succesfully find an annotation to delete. Also shows the underlying error message for User Helpfulness.

Closes #15