### PR TITLE
main.js: remove `require('./os.js')`

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,6 @@ const AWSManager = require('./backend/aws.js');
 const SessionMetadata = require('./backend/metadata.js')
 const sessionMetadata = new SessionMetadata();
 const { readUsername, writeUsername, submitUsername } = require('./username.js');
-const os = require('./os.js')
 
 let awsManager = null;
 


### PR DESCRIPTION
This was supposed to be part of #19 but instead it was included in the commit for #18.